### PR TITLE
chore: swaps `Extension Pack for Java` with Oracle extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 		"vscode": {
 			"extensions": [
 				"vscjava.vscode-gradle",
-				"vscjava.vscode-java-pack",
+				"Oracle.oracle-java",
 				"esbenp.prettier-vscode",
 				"donjayamanne.python-extension-pack",
 				"ms-vscode.vscode-typescript-next",


### PR DESCRIPTION
Resolves issues with Java support in VS Code by leveraging the Oracle extensions instead. This should result in faster builds and more reliable tool support for our Gradle-based projects.